### PR TITLE
Clean up tag item removal handling

### DIFF
--- a/paper-tags-input.html
+++ b/paper-tags-input.html
@@ -77,7 +77,7 @@ If you want to save it in bower.json file, remember to add flag --save
   <h3>{{label}}</h3> 
     <div class="clearfix" id="tags-items">
     <template is="dom-repeat" items="{{tags}}">
-      <tag-item font-color="{{fontColor}}" tag-color="{{tagColor}}" size="{{size}}" tags="{{tags}}" enable-remove="{{enableRemove}}" index="{{index}}" value="{{item}}"></tag-item>
+      <tag-item font-color="{{fontColor}}" tag-color="{{tagColor}}" size="{{size}}" enable-remove="{{enableRemove}}" index="{{index}}" value="{{item}}"></tag-item>
       </div>
     </template>
     </div>
@@ -165,9 +165,12 @@ If you want to save it in bower.json file, remember to add flag --save
       /**
        * Internal variable to hold the value of paper-input.
        */
-      _input_value: String,
+      _input_value: String
 
-
+    },
+    
+    listeners: {
+        'tag-item-remove': '_onTagItemRemove'
     },
 
     // Element Lifecycle
@@ -210,8 +213,8 @@ If you want to save it in bower.json file, remember to add flag --save
       if (typeof(this.tags) == 'undefined'){
         this.tags = [];
       }
-      this.tags.push(tag);
-      this.tags = this.tags.slice();  
+      
+      this.push('tags', tag);
     },
     /**
      * _getInputVal is the internal method to get the value of paper-input. It performs a trim on the value.
@@ -261,6 +264,15 @@ If you want to save it in bower.json file, remember to add flag --save
           var input = Polymer.dom(this.root).querySelector('#tag-input');;
           input.invalid=false;
         }
+    },
+    
+    /**
+     * Handler for 'tag-item-remove' event, which is fired when a <tag-item> is being removed.
+     *
+     * @param {Object} event object
+     */
+    _onTagItemRemove: function(e) {
+         this.splice('tags', e.detail.index, 1);
     }
 
   });

--- a/tag-item.html
+++ b/tag-item.html
@@ -88,6 +88,12 @@ tag-item is a tag element used by tags-input to show tags with a closed button.
     is: 'tag-item',
     properties: {
       /**
+      * Fired when the tag is to be removed from the tag list
+      *
+      * @event tag-item-remove
+      */
+      
+      /**
       * index of the tag
       */
        index:Number,
@@ -117,14 +123,8 @@ tag-item is a tag element used by tags-input to show tags with a closed button.
       /**
       * value of the tag
       */
-       value:String,
-      /**
-      * value of the tags
-      */
-       tags:{
-        type:Array,
-        notify: true
-      },
+       value:String
+       
     },
     /**
      * _containerColor is the internal method to compute background style
@@ -148,18 +148,12 @@ tag-item is a tag element used by tags-input to show tags with a closed button.
        return size + " tag-item-container";
      },
     /**
-     * _removeItem is the internal method to remove a tag from the tags list
-     *
-     * @param {object} event object
+     * Handler for removing the tag item
      */
-    _removeItem: function(e){
-      if (this.enableRemove == false){
-        return;
+     _removeItem: function() {
+      if (this.enableRemove === true) {
+        this.fire('tag-item-remove', {index: this.index});
       }
-      var parent = e.target.parentElement.parentElement.parentElement;
-      var index = parent.index;
-      this.tags.splice(index,1);
-      this.tags = this.tags.slice();  
     }
 
   });


### PR DESCRIPTION
- Decouples `<tag-item>` and `<paper-tags-input>` by firing event on tag removal rather than manipulating tag array directly (and removes some really fragile element accesses while we're at it)
- Use Polymer array manipulation methods to avoid having to slice array to force notification
