### PR TITLE
Update paper-tags-input.html

### DIFF
--- a/paper-tags-input.html
+++ b/paper-tags-input.html
@@ -59,21 +59,20 @@ If you want to save it in bower.json file, remember to add flag --save
 @demo
 -->
 <dom-module id="paper-tags-input">
-  <style>
-    :host {
-      display: block;
-      box-sizing: border-box;
-      font-family: 'Roboto', 'Noto', sans-serif;
-    }
-    .clearfix:after {
-     content: " ";
-     display: block;
-     height: 0;
-     clear: both;
-    }
-  </style>
-
   <template>
+    <style>
+      :host {
+        display: block;
+        box-sizing: border-box;
+        font-family: 'Roboto', 'Noto', sans-serif;
+      }
+      .clearfix:after {
+        content: " ";
+        display: block;
+        height: 0;
+        clear: both;
+      }
+    </style>
   <h3>{{label}}</h3>
     <div class="clearfix" >
     <template is="dom-repeat" items="{{tags}}">

--- a/tag-item.html
+++ b/tag-item.html
@@ -21,75 +21,72 @@ tag-item is a tag element used by tags-input to show tags with a closed button.
 @demo
 -->
 <dom-module id="tag-item">
-
-  <style>
-    :host {
-      display: block;
-      box-sizing: border-box;
-      font-family: 'Roboto', 'Noto', sans-serif;
-    }
-    .tag-value{
-      display: inline-block;
-      vertical-align: middle;
-    }
-    .tag-item-container{
-      background-color: var(--light-primary-color);
-      float: left;
-      margin-left: 6px;
-      margin-bottom: 3px;
-    }
-    .large.tag-item-container{
-      border-radius: 20px;
-      padding-left:14px;
-    }
-    .medium.tag-item-container{
-      border-radius: 17px;
-      padding-left: 11px;
-    }
-    .small.tag-item-container{
-      border-radius: 14px;
-      padding-left: 9px;
-    }
-
-    .large{
-      font-size:18px;
-    }
-    .large paper-icon-button{
-        height: 40px;
-        width: 40px;
-    }
-    .large paper-icon-button::shadow #icon{
-        width: 22px;
-        height: 22px;
-    }
-
-    .medium paper-icon-button{
-        height: 34px;
-        width: 34px;
-    }
-    .medium{
-      font-size:14px;
-    }
-    .medium paper-icon-button::shadow #icon{
-        width: 18px;
-        height: 18px;
-    }
-    .small paper-icon-button{
-        height: 30px;
-        width: 30px;
-    }
-    .small{
-      font-size:12px;
-    }
-    .small paper-icon-button::shadow #icon{
-        width: 14px;
-        height: 14px;
-    }
-
-
-  </style>
-
   <template>
+    <style>
+        :host {
+          display: block;
+          box-sizing: border-box;
+          font-family: 'Roboto', 'Noto', sans-serif;
+        }
+        .tag-value{
+          display: inline-block;
+          vertical-align: middle;
+        }
+        .tag-item-container{
+          background-color: var(--light-primary-color);
+          float: left;
+          margin-left: 6px;
+          margin-bottom: 3px;
+        }
+        .large.tag-item-container{
+          border-radius: 20px;
+          padding-left:14px;
+        }
+        .medium.tag-item-container{
+          border-radius: 17px;
+          padding-left: 11px;
+        }
+        .small.tag-item-container{
+          border-radius: 14px;
+          padding-left: 9px;
+        }
+
+        .large{
+          font-size:18px;
+        }
+        .large paper-icon-button{
+            height: 40px;
+            width: 40px;
+        }
+        .large paper-icon-button::shadow #icon{
+            width: 22px;
+            height: 22px;
+        }
+
+        .medium paper-icon-button{
+            height: 34px;
+            width: 34px;
+        }
+        .medium{
+          font-size:14px;
+        }
+        .medium paper-icon-button::shadow #icon{
+            width: 18px;
+            height: 18px;
+        }
+        .small paper-icon-button{
+            height: 30px;
+            width: 30px;
+        }
+        .small{
+          font-size:12px;
+        }
+        .small paper-icon-button::shadow #icon{
+            width: 14px;
+            height: 14px;
+        }
+      </style>
+
       <div style$="{{_containerColor(tagColor, fontColor)}}" class$="{{_containerClass(size)}}">
         <span class="tag-value">{{value}}</span>
         <template is="dom-if" if="{{enableRemove}}">
@@ -100,7 +97,6 @@ tag-item is a tag element used by tags-input to show tags with a closed button.
         </template>
       </div>
   </template>
-
 </dom-module>
 
 <script>


### PR DESCRIPTION
I get this warning in Chrome 70. The issue is that the style tag is outside the template tag.

![image](https://user-images.githubusercontent.com/1864112/56576718-d0f81400-65d1-11e9-8f04-0e88c54b943f.png)
